### PR TITLE
Add a hashmap to details of ports #45

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.14"
 simple_logger = "1.13.0"
 futures = "0.3.17"
 indicatif = "0.16.2"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 serial_test = "0.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[macro_use(lazy_static)] extern crate lazy_static;
 mod port_details;
 
 use ansi_term::Colour;
@@ -151,9 +152,17 @@ pub async fn scan(
         .await;
 
     pb.finish();
+    let details = port_details::DETAILS.lock().unwrap();
+    out_writer
+        .write(Colour::Green.paint(format!("Port\tService\t\tProtocol\n")).as_bytes())
+        .ok();
     for i in output_values.lock().await.iter() {
+        let d = match details.get(i) {
+            Some(detail) => detail,
+            None => ""
+        };
         out_writer
-            .write(Colour::Blue.paint(format!("{:?}\n", i)).as_bytes())
+            .write(Colour::Blue.paint(format!("{:?}\t{:?}\n", i, d)).as_bytes())
             .ok();
     }
 

--- a/src/port_details.rs
+++ b/src/port_details.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 pub const MOST_COMMON_PORTS: &[u16] = &[
     1, 3, 4, 6, 7, 9, 13, 17, 19, 20, 21, 22, 23, 24, 25, 26, 30, 32, 33, 37, 42, 43, 49, 53, 70,
     79, 80, 81, 82, 83, 84, 85, 88, 89, 90, 99, 100, 106, 109, 110, 111, 113, 119, 125, 135, 139,
@@ -64,3 +67,12 @@ pub const MOST_COMMON_PORTS: &[u16] = &[
     55056, 55555, 55600, 56737, 56738, 57294, 57797, 58080, 60020, 60443, 61532, 61900, 62078,
     63331, 64623, 64680, 65000, 65129, 65389,
 ];
+
+lazy_static! {
+    pub static ref DETAILS: Mutex<HashMap<u16, &'static str>> = {
+        let mut m = HashMap::new();
+        m.insert(80,  "http        tcp, udp, sctp");
+        m.insert(443, "https       tcp, udp, sctp");
+        Mutex::new(m)
+    };
+}


### PR DESCRIPTION
The hashmap is used to give more detailed information after port scan. The map should be extended in the future.