### PR TITLE
#60 example output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub async fn scan(
     pb.set_style(ProgressStyle::default_bar()
         .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos:>}/{len}  ({percent}%, {eta})")
         .progress_chars("##-"));
-    pb.set_message(format!("Scanning ports for {}", target));
+    pb.set_message(format!("Scanning ports for {} min-max ports:{},{}", target,min_port,max_port));
 
     ports
         .for_each_concurrent(concurrency, |port| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,8 @@ async fn main() -> Result<(), Error> {
                 "sctp" => 2,
                 _ => 0,
             }
-        } else if cmd_args.is_present("ports") {
+        } 
+        if cmd_args.is_present("ports") {
             let port_range: Vec<&str> = cmd_args.values_of("ports").unwrap().collect();
             if !port_range.is_empty() {
                 port1 = port_range[0]


### PR DESCRIPTION
```
PS D:\Projects\libfrizz> .\target\debug\frizz.exe -s -t 129.151.67.166 --ports 1000 1199
Scanning ports for 129.151.67.166 ports:1000,1199
  [00:00:03] [####################################################################################################] 199/199  (100%, 0s)
Port    Service         Protocol
Elapsed time to scan ports: 3.24s
```