### PR TITLE
Remove --protocol option "#62" "#60"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 # frizz -s -t example.net --ports 80 1024
 # frizz -s -t example.net --timeout 1 -c 1024
 # frizz -s -t example.net --timeout 1 -c 1024 -o output.txt
-# frizz -s -t example.net --timeout 1 --protocol sctp -o output
+# frizz -s -t example.net --timeout 1 --sctp -o output
+# frizz -s -t example.net --timeout 1 --tcp -o output
 ```
 
 Check [Git workflow](https://github.com/kursatkobya/libfrizz/wiki/Git-workflow) for how to contribute.

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -70,11 +70,20 @@ args:
       max_values: 2
       takes_value: true
       multiple: true
-  - protocol:
-      long: protocol
-      help: choose "tcp", "udp" or "sctp" to scan only tcp,udp or sctp ports
-      takes_value: true
-      default_value: "tcp"
+  - udp:
+      long: udp
+      help: scan only udp ports
+      takes_value: false
+      multiple: false
+  - tcp:
+      long: tcp
+      help: scan only tcp ports
+      takes_value: false
+      multiple: false
+  - sctp:
+      long: sctp
+      help: scan only sctp ports
+      takes_value: false
       multiple: false
   - progress-bar:
       short: "#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,15 +120,15 @@ async fn main() -> Result<(), Error> {
 
         let mut port1: u16 = 0;
         let mut port2: u16 = 0;
-        if cmd_args.is_present("protocol") {
-            let proto_opt = cmd_args.value_of("protocol").unwrap_or("tcp");
-            port1 = match proto_opt {
-                "tcp" => 0,
-                "udp" => 1,
-                "sctp" => 2,
-                _ => 0,
-            }
-        } 
+        let mut proto_opt = libfrizz::TransportLayerProtocol::None;
+        if cmd_args.is_present("udp") {
+            proto_opt = libfrizz::TransportLayerProtocol::Udp;
+        } else if cmd_args.is_present("tcp") {
+            proto_opt = libfrizz::TransportLayerProtocol::Tcp;
+        } else if cmd_args.is_present("sctp") {
+            proto_opt = libfrizz::TransportLayerProtocol::Sctp;
+        }
+
         if cmd_args.is_present("ports") {
             let port_range: Vec<&str> = cmd_args.values_of("ports").unwrap().collect();
             if !port_range.is_empty() {
@@ -147,6 +147,7 @@ async fn main() -> Result<(), Error> {
             timeout,
             cmp::min(port1, port2),
             cmp::max(port1, port2),
+            proto_opt,
             out_writer,
         )
         .await;

--- a/test-suite/run-tests.sh
+++ b/test-suite/run-tests.sh
@@ -42,7 +42,13 @@ $FRIZZEXEC -kv -t https://localhost/static_response -o test.txt
 $FRIZZEXEC -k -t https://localhost/static_response
 $FRIZZEXEC -k -# -t https://localhost/static_response
 $FRIZZEXEC -k --progress-bar -t https://localhost/static_response
+
+# caddy port scan
 $FRIZZEXEC -s -t localhost --ports 80 1024
+$FRIZZEXEC -s --udp -t example.org -o output
+$FRIZZEXEC -s --tcp -t example.org
+$FRIZZEXEC -s --sctp -t example.org --ports 80 1024
+
 
 # TODO after https://github.com/kursatkobya/libfrizz/issues/21 basic authentication imlpementation we can enable tests below
 #curl -uBob:hiccup -kv https://localhost/secret/test


### PR DESCRIPTION
This patch removes --protocol option and adds --udp, --tcp, --sctp
options instead.